### PR TITLE
Update AVC .version file to match forum thread with KSP compatibility

### DIFF
--- a/GameData/AstronomersVisualPack/AstronomersVisualPack.version
+++ b/GameData/AstronomersVisualPack/AstronomersVisualPack.version
@@ -1,1 +1,27 @@
-{"NAME":"Astronomer's Visual Pack","URL":"https://raw.githubusercontent.com/themaster402/AstronomersVisualPack/master/GameData/AstronomersVisualPack/AstronomersVisualPack.version","DOWNLOAD":"https://github.com/themaster402/AstronomersVisualPack/releases","CHANGE_LOG_URL":"https://forum.kerbalspaceprogram.com/index.php?/topic/160878-ksp-17-astronomers-visual-pack-v374-warpspeed","VERSION":{"MAJOR":3,"MINOR":8,"PATCH":3,"BUILD":0},"KSP_VERSION":{"MAJOR":1,"MINOR":7,"PATCH":3},"KSP_VERSION_MIN":{"MAJOR":1,"MINOR":6,"PATCH":0},"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":7,"PATCH":3}}
+{
+    "NAME": "Astronomer's Visual Pack",
+    "URL": "https://raw.githubusercontent.com/themaster402/AstronomersVisualPack/master/GameData/AstronomersVisualPack/AstronomersVisualPack.version",
+    "DOWNLOAD": "https://github.com/themaster402/AstronomersVisualPack/releases",
+    "CHANGE_LOG_URL": "https://forum.kerbalspaceprogram.com/index.php?/topic/160878-ksp-17-astronomers-visual-pack-v374-warpspeed",
+    "VERSION": {
+        "MAJOR": 3,
+        "MINOR": 8,
+        "PATCH": 3,
+        "BUILD": 0
+    },
+    "KSP_VERSION": {
+        "MAJOR": 1,
+        "MINOR": 7,
+        "PATCH": 3
+    },
+    "KSP_VERSION_MIN": {
+        "MAJOR": 1,
+        "MINOR": 6,
+        "PATCH": 0
+    },
+    "KSP_VERSION_MAX": {
+        "MAJOR": 1,
+        "MINOR": 8,
+        "PATCH": 1
+    }
+}


### PR DESCRIPTION
The forum thread says v3.83 is compatible with KSP 1.8, but the version file says otherwise.
This PR changes the `KSP_VERSION_MAX` to `1.8.1`.

This will also trigger a metadata update on CKAN once the PR is merged so CKAN finally shows the mod as 1.8 compatible.
Also AVC stops complaining.